### PR TITLE
experimenting with node positioning

### DIFF
--- a/Directed Graph/createNode.js
+++ b/Directed Graph/createNode.js
@@ -13,6 +13,11 @@ function makeLink(from,to) {
         '.connection': { stroke: 'red', 'stroke-dasharray': '5,5' }
        }
      });
+     // see https://resources.jointjs.com/docs/jointjs/v3.7/joint.html#routers
+     // I haven't tried the other algorithms but it might be worth experimenting
+     // with them all to see which works best
+     link.router('manhattan');
+     link.connector('jumpover');
      link.set('hidden', true);
       return link
  }
@@ -97,10 +102,10 @@ function createStage(id, name){
 function createTopics(id, name){
     const node = new joint.shapes.standard.Rectangle({
         id: id,
-        position: {
-          x: 250,
-          y: 500
-        },
+        //position: {
+        //  x: 250,
+        //  y: 500
+        //},
         size: {
           width: '250',
           height: 45
@@ -157,8 +162,8 @@ function createTopics(id, name){
                   fontFamily: "sans-serif"
                 },
               },
-              size: { width: PORT_WIDTH, height: PORT_HEIGHT },
-              position: "absolute"
+              size: { width: PORT_WIDTH, height: PORT_HEIGHT }
+              //position: "absolute"
             },
           },
           items: []
@@ -172,7 +177,7 @@ function createTopics(id, name){
 
     return new joint.shapes.standard.Rectangle({
         id: id,
-        position: { x:100, y: 50 },
+        //position: { x:100, y: 50 },
         size: { width: 100, height: 40 },
         attrs: {
             rect: { fill: 'lightblue', stroke: 'blue', 'stroke-width': 2 },
@@ -201,7 +206,7 @@ function createTopics(id, name){
 
     return new joint.shapes.standard.Rectangle({
         id: id,
-        position: { x:100, y: 50 },
+        //position: { x:100, y: 50 },
         size: { width: 100, height: 40 },
         attrs: {
             rect: { fill: 'lightblue', stroke: 'blue', 'stroke-width': 2 },
@@ -231,7 +236,7 @@ function createTopics(id, name){
 
     return new joint.shapes.standard.Rectangle({
         id: id,
-        position: { x:100, y: 50 },
+        //position: { x:100, y: 50 },
         size: { width: 100, height: 40 },
         attrs: {
             rect: { fill: 'lightblue', stroke: 'blue', 'stroke-width': 2 },
@@ -261,10 +266,10 @@ function createTopics(id, name){
     const width = Math.max(textWidth, 100); // Ensure a minimum width to accommodate shorter text
     const node =  new joint.shapes.standard.Rectangle({
         id: id,
-        position: {
-          x: 250,
-          y: 500
-        },
+        //position: {
+        //  x: 250,
+        //  y: 500
+        //},
         size: {
           width: width,
           height: 45
@@ -321,8 +326,8 @@ function createTopics(id, name){
                   fontFamily: "sans-serif"
                 },
               },
-              size: { width: PORT_WIDTH, height: PORT_HEIGHT },
-              position: "absolute"
+              size: { width: PORT_WIDTH, height: PORT_HEIGHT }
+              //position: "absolute"
             },
           },
           items: []

--- a/Directed Graph/direct.html
+++ b/Directed Graph/direct.html
@@ -9,14 +9,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.4.0/backbone-min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.4.4/joint.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.7/joint.min.js"></script>
     
 <!-- Add these script tags to include JointJS and Dagre -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.1.2/joint.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.7/joint.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dagre/0.7.4/dagre.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/graphlib/2.1.7/graphlib.min.js"></script>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.4.4/joint.min.css" rel="stylesheet" />
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.4.1/joint.min.css">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.7/joint.min.css" rel="stylesheet" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.7/joint.min.css">
 <link rel="stylesheet" href="./style.css">
 </head>
 <body>

--- a/Directed Graph/direct.js
+++ b/Directed Graph/direct.js
@@ -24,6 +24,12 @@ const paper = new dia.Paper({
 paper.on('element:pointerclick', function(view, evt) {
     evt.stopPropagation();
     toggleBranch(view.model);
+    // resetting the layout here has an effect after collapsing and then moving the topic nodes 
+    // manually to be closer (it moves them so the expanded nodes will fit if you re-expand after
+    // moving. It doesn't seem to have any effect after just collapsing a node's children 
+    // though. So I think it has promise as an approach but more work is needed to figure out
+    // how to get the layout to redraw everytime the way we want it to
+    doLayout();
 })
         
 
@@ -98,13 +104,7 @@ function buildTheGraph(){
       });
       graph.addCells(Elements)
       //graph.addCells(Elements.concat(Links))
-      joint.layout.DirectedGraph.layout(graph, {
-        setLinkVertices: false, // Optional: Prevent the plugin from setting link vertices
-        nodeSep: 50,
-        edgeSep: 80,
-        rankDir: "LR",
-        ranker: 'network-simplex'
-    });
+      layout = doLayout();
    })
 }
 
@@ -138,20 +138,25 @@ function checkOutcomes(topic, arr, parentNode){
   
 }
 
+function doLayout() {
+  // Apply layout using DirectedGraph plugin
+  layout = joint.layout.DirectedGraph.layout(graph, {
+	  // commenting these out had no effect - maybe they are overridden by the router algorithm?
+//      setLinkVertices: false, // Optional: Prevent the plugin from setting link vertices
+//      nodeSep: 50,
+ //     edgeSep: 80,
+      rankDir: "LR",
+      ranker: 'tight-tree'
+  });
+  return layout;
+}
 
 buildTheGraph();
+//doLayout();
 
 
 // Add nodes and link to the graph
 //graph.addCells([rect, circle, link, circle2, link2, rect2, link3, link4, rect3, link5]);
-// Apply layout using DirectedGraph plugin
-joint.layout.DirectedGraph.layout(graph, {
-    setLinkVertices: false, // Optional: Prevent the plugin from setting link vertices
-    nodeSep: 50,
-    edgeSep: 80,
-    rankDir: "LR",
-    ranker: 'network-simplex'
-});
 
 
 

--- a/Directed Graph/events.js
+++ b/Directed Graph/events.js
@@ -8,6 +8,9 @@ function toggleBranch(child) {
 }
 
 function openBranch(child, shouldHide){
+    // TODO: openBranch should only open the next level of the tree, not the
+    // full tree - this might also help with the initial layout
+
     //Finds the outgoing links to the element the user is interacting with
     const findTarget = graph.getConnectedLinks(child, {outbound:true})
     //Using each link that is connected find the target Elements and play with them
@@ -18,6 +21,7 @@ function openBranch(child, shouldHide){
         element.set('collapsed', false)
         //Make the links visible
         targetLink.set('hidden', shouldHide)
+	
         if(!element.get('collapsed')){
             console.log(element.get('collapsed'))
             const subElementsLinks = graph.getConnectedLinks(element, {outbound:true})
@@ -31,6 +35,11 @@ function openBranch(child, shouldHide){
             })
             
         }
+	// I don't think I'm calling this correctly, or in the right
+	// place but see https://resources.jointjs.com/docs/jointjs/v3.7/joint.html#dia.LinkView.prototype.requestConnectionUpdate
+	// in theory it should help with recalculating the routes after
+	// things move
+	paper.findViewByModel(targetLink).requestConnectionUpdate();
         
     })
 

--- a/buttons/index.html
+++ b/buttons/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JointJS with Custom Tool Buttons per Port</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.4.0/backbone-min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.7/joint.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jointjs/3.7.7/joint.min.css">
+</head>
+<body>
+  <div id="diagram"></div>
+  
+  <script src="ports.js"></script>
+</body>
+</html>

--- a/buttons/ports.js
+++ b/buttons/ports.js
@@ -1,0 +1,103 @@
+var namespace = joint.shapes;
+var graph = new joint.dia.Graph({}, { cellNamespace: namespace });
+var paper = new joint.dia.Paper({
+  el: document.getElementById('diagram'),
+  width: 600,
+  height: 400,
+  model: graph,
+});
+
+var rect = new joint.shapes.standard.Rectangle({
+    position: { x: 275, y: 50 },
+    size: { width: 90, height: 90 },
+    attrs: {
+        body: {
+            fill: '#8ECAE6'
+        }
+    },
+    ports: {
+        items: [ ] 
+    }
+});
+
+function createPort(id,group,label) {
+  var port = {
+    id: id,
+    label: {
+      position: {
+        name: 'left'
+      },
+      markup: [{
+         tagName: 'text',
+            selector: 'label'
+        }]
+    },
+    attrs: {
+        portBody: {
+            magnet: true,
+            width: 16,
+            height: 16,
+            x: -8,
+            y: -8,
+            fill:  '#03071E'
+        },
+        label: {
+            text: label
+        }
+    },
+    markup: [{
+        tagName: 'rect',
+        selector: 'portBody'
+    }]
+  };
+  return port
+}
+function createButton(port,pos) {
+  var button  = new joint.elementTools.Button({
+    position: {
+      name: 'left'
+    },
+    markup: [
+      {
+        tagName: 'circle',
+        selector: 'button',
+        attributes: {
+          'r': 10,
+          'fill': '#cc0000',
+          'cursor': 'pointer'
+        }
+      },
+      {
+        tagName: 'text',
+        textContent: port.id,
+        selector: 'text',
+        attributes: {
+          'fill': '#ffffff',
+          'font-size': 10,
+          'font-family': 'Arial, helvetica, sans-serif',
+          'text-anchor': 'middle',
+          'pointer-events': 'none',
+        }
+      }
+    ],
+    x: '100%',
+    y: '100%',
+    offset: { x: -8, y: -8 },
+    action: function(evt) {
+      alert(`Clicked button for port ${port.id}`);
+      // You can perform any action you want here
+    }
+   });
+   return button;
+}
+var port1 = createPort('port1', 'out', 'Port 1');
+var port2 = createPort('port2', 'out', 'Port 2');
+// Add custom tool buttons for each port
+var tools = [];
+[port1, port2].forEach(port => {
+  rect.addPort(port);
+  tools.push(createButton(port))
+});
+graph.addCells(rect);
+toolsView = new joint.dia.ToolsView({ tools: tools});
+rect.findView(paper).addTools(toolsView);


### PR DESCRIPTION
I didn't have time to get as far with this as I had wanted, but there are a few things you can hopefully investigate further. See my comments for additional info but:

1) I think we can use a pre-defined routing algorithm on the links to get them to layout more nicely
2) redoing the layout after manually moving a collapsed node works to get the layout to redraw itself to make room for the children. I haven't been able so far to get it to redraw after just collapsing a node but it must be possible. Needs further investigation.
3) We should only expand the first level of a node when it's clicked on. This could potentially help with the initial drawing size.  A brute force approach might also be to simply remove all the children from a node when it's closed, but I think that really wouldn't be ideal.
4) I commented out all the hard-coded positions, except for on the stage nodes, thinking that might have been interfering with the automatic routing and layout algorithms, but it didn't have any effect. I think we should reduce all the positioning information in the elements to the bare minimum, and then build them back up as needed.